### PR TITLE
Windows Support (~ location issue)

### DIFF
--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -75,7 +75,7 @@ function s:Delete()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if s:is_win
-       b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
+       let b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
        exec b:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -50,8 +50,8 @@ function s:Add()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if s:is_win
-       l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
-       exec l:scrpt
+       let b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+       exec b:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
    endif   
@@ -75,8 +75,8 @@ function s:Delete()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if s:is_win
-       l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
-       exec l:scrpt
+       b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
+       exec b:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
    endif

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -48,7 +48,7 @@ function s:Add()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+   exec 'silent !emacs -batch -l ~/elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
    exec 'silent %!cat %.emacsautotmp '
    if &expandtab
       retab
@@ -67,7 +67,7 @@ function s:Delete()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
+   exec 'silent !emacs -batch -l ~/elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
    exec 'silent %!cat %.emacsautotmp'
    exec 'silent !rm %.emacsautotmp'
    exec 'redraw!'

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -75,7 +75,7 @@ function s:Delete()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if s:is_win
-       let b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
+       let b:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp/").'verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
        exec b:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -48,7 +48,13 @@ function s:Add()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   exec 'silent !emacs -batch -l ~/elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+   if g:env =~ 'WINDOWS'
+       l:scrpt = 'silent !emacs -batch -l ' + expand("$HOME/.elisp") + 'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+       exec l:scrpt
+   else
+       exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+   endif   
+   
    exec 'silent %!cat %.emacsautotmp '
    if &expandtab
       retab
@@ -67,7 +73,12 @@ function s:Delete()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   exec 'silent !emacs -batch -l ~/elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
+   if g:env =~ 'WINDOWS'
+       l:scrpt = 'silent !emacs -batch -l ' + expand("$HOME/.elisp") + 'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
+       exec l:scrpt
+   else
+       exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'
+   endif
    exec 'silent %!cat %.emacsautotmp'
    exec 'silent !rm %.emacsautotmp'
    exec 'redraw!'

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -49,7 +49,7 @@ function s:Add()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if g:env =~ 'WINDOWS'
-       l:scrpt = 'silent !emacs -batch -l ' + expand("$HOME/.elisp") + 'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
+       l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
        exec l:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
@@ -74,7 +74,7 @@ function s:Delete()
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
    if g:env =~ 'WINDOWS'
-       l:scrpt = 'silent !emacs -batch -l ' + expand("$HOME/.elisp") + 'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
+       l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
        exec l:scrpt
    else
        exec 'silent !emacs -batch -l ~/.elisp/verilog-mode.el %.emacsautotmp -f verilog-batch-delete-auto'

--- a/plugin/systemverilog_emacsauto.vim
+++ b/plugin/systemverilog_emacsauto.vim
@@ -13,6 +13,7 @@ if exists("loaded_verilog_emacsauto")
    finish
 endif
 let loaded_verilog_emacsauto = 1
+let s:is_win = has('win32')
 
 " map \a, \d pair to Add and Delete functions, assuming \ is the leader
 " alternatively, map C-A, C-D to Add and Delete functions
@@ -48,7 +49,7 @@ function s:Add()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   if g:env =~ 'WINDOWS'
+   if s:is_win
        l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-batch-auto'
        exec l:scrpt
    else
@@ -73,7 +74,7 @@ function s:Delete()
    " a tmp file is need 'cause emacs doesn't support the stdin to stdout flow
    " maybe add /tmp to the temporary filename
    w! %.emacsautotmp
-   if g:env =~ 'WINDOWS'
+   if s:is_win
        l:scrpt = 'silent !emacs -batch -l '.expand("$HOME/.elisp").'verilog-mode.el %.emacsautotmp -f verilog-delete-auto'
        exec l:scrpt
    else


### PR DESCRIPTION
I had a trouble to run this plugin in Windows.
So I wanted to discuss the windows support issue, But there is no issue tab.

My understanding is that emacs windows version doest not understand the "~/.elisp".
So I change your script a little using expand("%HOME/.elisp") with the assumption user added environment variable HOME to c:\Users\user_id.

Review the codes please. And if you like it, please merge this one.